### PR TITLE
Support per-statement code lenses

### DIFF
--- a/editor-extensions/vscode/client/src/CodeLensProvider.ts
+++ b/editor-extensions/vscode/client/src/CodeLensProvider.ts
@@ -2,6 +2,9 @@ import * as vscode from 'vscode';
 
 /**
  * CodelensProvider
+ * 
+ * Dummy, used to trigger lens updates until LSP protocol supports onDidChangeCodeLenses 
+ * (coming in 3.16.0)
  */
 export class CodelensProvider implements vscode.CodeLensProvider {
 
@@ -19,46 +22,14 @@ export class CodelensProvider implements vscode.CodeLensProvider {
 	}
 
 	public provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.CodeLens[] | Thenable<vscode.CodeLens[]> {
-		console.log("DUMMY provideCodeLenses called");
-		// if (vscode.workspace.getConfiguration("codelens-sample").get("enableCodeLens", true)) {
-		//     this.codeLenses = [];
-		//     const regex = new RegExp(this.regex);
-		//     const text = document.getText();
-		//     let matches;
-		//     while ((matches = regex.exec(text)) !== null) {
-		//         const line = document.lineAt(document.positionAt(matches.index).line);
-		//         const indexOf = line.text.indexOf(matches[0]);
-		//         const position = new vscode.Position(line.lineNumber, indexOf);
-		//         const range = document.getWordRangeAtPosition(position, new RegExp(this.regex));
-		//         if (range) {
-		//             this.codeLenses.push(new vscode.CodeLens(range));
-		//         }
-		//     }
-		//     return this.codeLenses;
-		// }
 		return [];
 	}
 
 	public resolveCodeLens(codeLens: vscode.CodeLens, token: vscode.CancellationToken) {
-		console.log("DUMMY resolveCodeLens called");
-
-		// if (vscode.workspace.getConfiguration("codelens-sample").get("enableCodeLens", true)) {
-		//     codeLens.command = {
-		//         title: "Codelens provided by sample extension",
-		//         tooltip: "Tooltip provided by sample extension",
-		//         command: "codelens-sample.codelensAction",
-		//         arguments: ["Argument 1", false]
-		//     };
-		//     return codeLens;
-		// }
-		// return null;
 		return codeLens;
 	}
 
 	public triggerRefresh() {
-
-		console.log("triggerRefresh");
-
 		this._onDidChangeCodeLenses.fire();
 	}
 }

--- a/editor-extensions/vscode/client/src/CodeLensProvider.ts
+++ b/editor-extensions/vscode/client/src/CodeLensProvider.ts
@@ -1,0 +1,65 @@
+import * as vscode from 'vscode';
+
+/**
+ * CodelensProvider
+ */
+export class CodelensProvider implements vscode.CodeLensProvider {
+
+	private codeLenses: vscode.CodeLens[] = [];
+	private regex: RegExp;
+	private _onDidChangeCodeLenses: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
+	public readonly onDidChangeCodeLenses: vscode.Event<void> = this._onDidChangeCodeLenses.event;
+
+	constructor() {
+		this.regex = /(.+)/g;
+
+		vscode.workspace.onDidChangeConfiguration((_) => {
+			this._onDidChangeCodeLenses.fire();
+		});
+	}
+
+	public provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.CodeLens[] | Thenable<vscode.CodeLens[]> {
+		console.log("DUMMY provideCodeLenses called");
+		// if (vscode.workspace.getConfiguration("codelens-sample").get("enableCodeLens", true)) {
+		//     this.codeLenses = [];
+		//     const regex = new RegExp(this.regex);
+		//     const text = document.getText();
+		//     let matches;
+		//     while ((matches = regex.exec(text)) !== null) {
+		//         const line = document.lineAt(document.positionAt(matches.index).line);
+		//         const indexOf = line.text.indexOf(matches[0]);
+		//         const position = new vscode.Position(line.lineNumber, indexOf);
+		//         const range = document.getWordRangeAtPosition(position, new RegExp(this.regex));
+		//         if (range) {
+		//             this.codeLenses.push(new vscode.CodeLens(range));
+		//         }
+		//     }
+		//     return this.codeLenses;
+		// }
+		return [];
+	}
+
+	public resolveCodeLens(codeLens: vscode.CodeLens, token: vscode.CancellationToken) {
+		console.log("DUMMY resolveCodeLens called");
+
+		// if (vscode.workspace.getConfiguration("codelens-sample").get("enableCodeLens", true)) {
+		//     codeLens.command = {
+		//         title: "Codelens provided by sample extension",
+		//         tooltip: "Tooltip provided by sample extension",
+		//         command: "codelens-sample.codelensAction",
+		//         arguments: ["Argument 1", false]
+		//     };
+		//     return codeLens;
+		// }
+		// return null;
+		return codeLens;
+	}
+
+	public triggerRefresh() {
+
+		console.log("triggerRefresh");
+
+		this._onDidChangeCodeLenses.fire();
+	}
+}
+

--- a/editor-extensions/vscode/client/src/extension.ts
+++ b/editor-extensions/vscode/client/src/extension.ts
@@ -25,10 +25,7 @@ let disposables: Disposable[] = [];
 
 let codelensProvider: CodelensProvider;
 
-
 export function activate(context: ExtensionContext) {
-
-
 
 	// The server is implemented in node
 	let serverModule = context.asAbsolutePath(
@@ -75,11 +72,8 @@ export function activate(context: ExtensionContext) {
 	);
 
 	client.onReady().then(() => {
-		console.log("adding notification handler");
 		client.onNotification("grainlsp/lensesLoaded", (files: Array<String>) => {
-			console.log("lensesLoaded called");
 			codelensProvider.triggerRefresh();
-
 		});
 	});
 

--- a/editor-extensions/vscode/client/src/extension.ts
+++ b/editor-extensions/vscode/client/src/extension.ts
@@ -6,7 +6,8 @@
  * ------------------------------------------------------------------------------------------ */
 
 import * as path from 'path';
-import { workspace, ExtensionContext } from 'vscode';
+import { workspace, ExtensionContext, languages, Disposable } from 'vscode';
+
 
 import {
 	LanguageClient,
@@ -17,7 +18,13 @@ import {
 
 let client: LanguageClient;
 
+let disposables: Disposable[] = [];
+
+
 export function activate(context: ExtensionContext) {
+
+
+
 	// The server is implemented in node
 	let serverModule = context.asAbsolutePath(
 		path.join('server', 'out', 'server.js')
@@ -60,6 +67,10 @@ export function activate(context: ExtensionContext) {
 }
 
 export function deactivate(): Thenable<void> | undefined {
+	if (disposables) {
+		disposables.forEach(item => item.dispose());
+	}
+	disposables = [];
 	if (!client) {
 		return undefined;
 	}

--- a/editor-extensions/vscode/package.json
+++ b/editor-extensions/vscode/package.json
@@ -58,6 +58,12 @@
 					"default": true,
 					"description": "Enable the language server"
 				},
+				"grain_language_server.enableStatementLenses": {
+					"scope": "window",
+					"type": "boolean",
+					"default": true,
+					"description": "Enable per-statement lenses"
+				},
 				"grain_language_server.maxNumberOfProblems": {
 					"scope": "resource",
 					"type": "number",

--- a/editor-extensions/vscode/server/src/server.ts
+++ b/editor-extensions/vscode/server/src/server.ts
@@ -339,8 +339,6 @@ connection.onCodeLens(handler => {
 
 	let codeLenses: CodeLens[] = [];
 
-
-
 	if (documentLenses.has(handler.textDocument.uri)) {
 
 		let docLenses = documentLenses.get(handler.textDocument.uri);
@@ -369,7 +367,7 @@ connection.onCodeLensResolve(codeLens => {
 
 	codeLens.command = {
 		title: data,
-		command: "codelens-sample.codelensAction",
+		command: "",
 		arguments: []
 	};
 	return codeLens;

--- a/editor-extensions/vscode/server/src/server.ts
+++ b/editor-extensions/vscode/server/src/server.ts
@@ -76,7 +76,6 @@ async function processChangedDocuments(): Promise<void> {
 
 connection.onInitialize((params: InitializeParams) => {
 
-	connection.console.log("onInitialize");
 
 	let capabilities = params.capabilities;
 
@@ -125,7 +124,7 @@ connection.onInitialized(() => {
 	}
 	if (hasWorkspaceFolderCapability) {
 		connection.workspace.onDidChangeWorkspaceFolders(_event => {
-			connection.console.log('Workspace folder change event received.');
+			//	connection.console.log('Workspace folder change event received.');
 		});
 	}
 
@@ -260,7 +259,6 @@ async function validateWithCompiler(textDocumentUri: string): Promise<void> {
 						if (settings.enableStatementLenses) {
 
 							if (lenses.length > 0) {
-								connection.console.log("We have lenses");
 								if (documentLenses.has(textDocumentUri)) {
 									documentLenses.delete(textDocumentUri);
 								}
@@ -268,7 +266,6 @@ async function validateWithCompiler(textDocumentUri: string): Promise<void> {
 
 								// work around LSP not having an onDidChangeCodeLenses yet
 								// If we don' call this we are always one step behind
-								connection.console.log("Sending notification");
 								connection.sendNotification("grainlsp/lensesLoaded", []);
 							}
 						} else {

--- a/editor-extensions/vscode/server/src/server.ts
+++ b/editor-extensions/vscode/server/src/server.ts
@@ -172,10 +172,15 @@ connection.onDidChangeConfiguration(change => {
 		);
 	}
 
+	documentLenses = new Map();
+
+
 	// clear down the list as we're going to process them all below.
 	changedDocuments = new Set();
 	// Revalidate all open text documents
 	documents.all().forEach(doc => validateWithCompiler(doc.uri));
+
+
 
 });
 


### PR DESCRIPTION
Adds support for per-statement code lenses.

Breaking change as it requires the matching new LSP mode changes to the grainc compiler lsp mode.  This has been turned into generic JSON now so is more flexible for future changes.

