### PR TITLE
Add basic support for `type` syntax highlighting

### DIFF
--- a/editor-extensions/vscode/syntaxes/grain.json
+++ b/editor-extensions/vscode/syntaxes/grain.json
@@ -317,6 +317,13 @@
             "2": { "name": "entity.name.type.grain" },
             "3": { "patterns": [{ "include": "#type-vector" }] }
           }
+        },
+        {
+          "match": "(type)\\s+(.*)",
+          "captures": {
+            "1": { "name": "storage.type.grain" },
+            "2": { "patterns": [{ "include": "#type" }] }
+          }
         }
       ]
     },
@@ -786,7 +793,7 @@
     "keywords": {
       "patterns": [
         {
-          "match": "\\b(throw|let|rec|mut|and|record|enum|while|match|when|pattern|assert|fail|import|export|foreign|primitive|from|except|as)\\b",
+          "match": "\\b(throw|let|rec|mut|and|type|record|enum|while|match|when|pattern|assert|fail|import|export|foreign|primitive|from|except|as)\\b",
           "name": "keyword.control.grain"
         }
       ]


### PR DESCRIPTION
I know this rule is kind of silly, but it's a "good enough" rule for what we need it for at the moment.