### PR TITLE
feat: Add specific grain-type grammar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 *.vsix
 editor-extensions/vscode/client/out
 editor-extensions/vscode/server/out
+editor-extensions/vscode/syntaxes/grain-type.json

--- a/editor-extensions/vscode/client/src/extension.ts
+++ b/editor-extensions/vscode/client/src/extension.ts
@@ -46,7 +46,7 @@ export function activate(context: ExtensionContext) {
   // Options to control the language client
   let clientOptions: LanguageClientOptions = {
     // Register the server for plain text documents
-    documentSelector: [{ scheme: "file", language: "grain" }],
+    documentSelector: [{ scheme: "file", language: "grain-type" }],
     synchronize: {
       // Notify the server about file changes to '.clientrc files contained in the workspace
       fileEvents: workspace.createFileSystemWatcher("**/.clientrc"),

--- a/editor-extensions/vscode/client/src/extension.ts
+++ b/editor-extensions/vscode/client/src/extension.ts
@@ -46,7 +46,7 @@ export function activate(context: ExtensionContext) {
   // Options to control the language client
   let clientOptions: LanguageClientOptions = {
     // Register the server for plain text documents
-    documentSelector: [{ scheme: "file", language: "grain-type" }],
+    documentSelector: [{ scheme: "file", language: "grain" }],
     synchronize: {
       // Notify the server about file changes to '.clientrc files contained in the workspace
       fileEvents: workspace.createFileSystemWatcher("**/.clientrc"),

--- a/editor-extensions/vscode/package.json
+++ b/editor-extensions/vscode/package.json
@@ -39,6 +39,13 @@
           ".gr"
         ],
         "configuration": "./language-configuration.json"
+      },
+      {
+        "id": "grain-type",
+        "aliases": [
+          "Grain Type"
+        ],
+        "configuration": "./language-configuration.json"
       }
     ],
     "grammars": [
@@ -46,6 +53,11 @@
         "language": "grain",
         "scopeName": "source.grain",
         "path": "./syntaxes/grain.json"
+      },
+      {
+        "language": "grain-type",
+        "scopeName": "source.grain-type",
+        "path": "./syntaxes/grain-type.json"
       }
     ],
     "configuration": {
@@ -97,7 +109,7 @@
     }
   },
   "scripts": {
-    "compile": "tsc -b",
+    "compile": "tsc -b && node syntaxes/generate-grain-type.js",
     "watch": "tsc -b -w",
     "postinstall": "cd client && npm install && cd ../server && npm install && cd ..",
     "test": "sh ./scripts/e2e.sh",

--- a/editor-extensions/vscode/server/src/server.ts
+++ b/editor-extensions/vscode/server/src/server.ts
@@ -499,7 +499,7 @@ connection.onHover((params: TextDocumentPositionParams): Hover | undefined => {
   if (bestmatch == undefined) {
     return undefined;
   } else {
-    let doc = [{ language: "grain", value: bestmatch!.s }];
+    let doc = [{ language: "grain-type", value: bestmatch!.s }];
     return {
       contents: doc,
     };

--- a/editor-extensions/vscode/syntaxes/generate-grain-type.js
+++ b/editor-extensions/vscode/syntaxes/generate-grain-type.js
@@ -1,0 +1,22 @@
+const fs = require("fs");
+const path = require("path");
+const grain = require("./grain.json");
+
+const grainType = {
+  ...grain,
+  name: "Grain Type",
+  patterns: [
+    {
+      include: "#data-declarations",
+    },
+    {
+      include: "#type",
+    },
+  ],
+  scopeName: "source.grain-type",
+};
+
+fs.writeFileSync(
+  path.join(__dirname, "grain-type.json"),
+  JSON.stringify(grainType)
+);


### PR DESCRIPTION
This PR adds a new grammar that highlights Grain types, to be used with tooling. It can be used by supplying `language: 'grain-type'`.

In the future, we could optimize this by looking at the `patterns` key and recursively only keeping values in the repository that are used, but that's complex and probably not necessary.

With this, we probably don't need #32.