### PR TITLE
Better scope for enum variants

### DIFF
--- a/editor-extensions/vscode/syntaxes/grain.json
+++ b/editor-extensions/vscode/syntaxes/grain.json
@@ -880,7 +880,7 @@
           "begin": "\\b([A-Z]\\w*)\\b\\s*(\\()",
           "end": "(\\))",
           "beginCaptures": {
-            "1": { "name": "support.type.grain" },
+            "1": { "patterns": [{"include": "#type-variant-name"}] },
             "2": { "name": "punctuation.definition.parameters.begin.grain" }
           },
           "endCaptures": {
@@ -890,7 +890,7 @@
             {
               "match": "(,)",
               "captures": {
-                "1": { "name": "support.type.grain" }
+                "1": { "name": "punctuation.definition.parameters.grain" }
               }
             },
             { "include": "#type" }
@@ -899,15 +899,15 @@
         {
           "match": "\\b([A-Z]\\w*)\\b",
           "captures": {
-            "1": { "name": "support.type.grain" }
+            "1": { "patterns": [{"include": "#type-variant-name"}] }
           }
         },
         {
           "comment": "Special support for the List type in Pervasives.",
           "match": "((\\[\\])|(\\[\\.\\.\\.])(\\(a, List<a>\\)))",
           "captures": {
-            "2": { "name": "support.type.grain" },
-            "3": { "name": "support.type.grain" },
+            "2": { "name": "entity.name.function.grain" },
+            "3": { "name": "entity.name.function.grain" },
             "4": { "patterns": [{ "include": "#type" }] }
           }
         },
@@ -915,6 +915,16 @@
           "comment": "Special support for the constant types in Pervasives.",
           "match": "(true|false|void)",
           "patterns": [{ "include": "#constant" }]
+        }
+      ]
+    },
+    "type-variant-name": {
+      "patterns": [
+        {
+          "match": "\\b([A-Z]\\w*)\\b",
+          "captures": {
+            "1": { "name": "entity.name.function.grain" }
+          }
         }
       ]
     },
@@ -927,7 +937,7 @@
           "begin": "\\b([A-Z]\\w*)\\b\\s*(\\()",
           "end": "(\\))",
           "beginCaptures": {
-            "1": { "name": "support.type.grain" },
+            "1": { "patterns": [{"include": "#type-variant-name"}] },
             "2": { "name": "punctuation.definition.parameters.begin.grain" }
           },
           "endCaptures": {
@@ -937,7 +947,7 @@
             {
               "match": "(,)",
               "captures": {
-                "1": { "name": "support.type.grain" }
+                "1": { "name": "punctuation.definition.parameters.grain" }
               }
             },
             { "include": "#expressions" }
@@ -946,7 +956,7 @@
         {
           "match": "\\b([A-Z]\\w*)\\b",
           "captures": {
-            "1": { "name": "support.type.grain" }
+            "1": { "patterns": [{"include": "#type-variant-name"}] }
           }
         },
         {
@@ -1022,7 +1032,7 @@
           "begin": "\\b([A-Z]\\w*)\\b(?=\\s*\\()",
           "end": "(?<=\\))",
           "beginCaptures": {
-            "1": { "name": "support.type.grain" }
+            "1": { "patterns": [{"include": "#type-variant-name"}] }
           },
           "patterns": [
             {
@@ -1047,7 +1057,7 @@
                 {
                   "match": "(,)",
                   "captures": {
-                    "1": { "name": "support.type.grain" }
+                    "1": { "name": "punctuation.definition.parameters.grain" }
                   }
                 },
                 {
@@ -1072,7 +1082,7 @@
         {
           "match": "\\b([A-Z]\\w*)\\b",
           "captures": {
-            "1": { "name": "support.type.grain" }
+            "1": { "patterns": [{"include": "#type-variant-name"}] }
           }
         },
         {
@@ -1101,7 +1111,7 @@
           "begin": "(=>)\\s*(\\{)",
           "end": "(\\})",
           "beginCaptures": {
-            "1": { "name": "support.type.grain" },
+            "1": { "name": "keyword.operator.grain" },
             "2": { "name": "punctuation.definition.parameters.start.grain" }
           },
           "endCaptures": {
@@ -1113,7 +1123,7 @@
           "begin": "(=>)",
           "end": "((?=,)(?<!,)|(?=\\}))",
           "beginCaptures": {
-            "1": { "name": "support.type.grain" }
+            "1": { "name": "keyword.operator.grain" }
           },
           "patterns": [{ "include": "#expressions" }]
         },


### PR DESCRIPTION
Enum variants are used like functions in Grain, so `entity.name.function` is a better scope to apply than `support.type`.