### PR TITLE
Highlight extended string escapes

### DIFF
--- a/editor-extensions/vscode/syntaxes/grain.json
+++ b/editor-extensions/vscode/syntaxes/grain.json
@@ -789,8 +789,7 @@
           "end": "\"",
           "patterns": [
             {
-              "name": "constant.character.escape.grain",
-              "match": "\\\\."
+              "include": "#string-escape"
             }
           ]
         },
@@ -800,10 +799,17 @@
           "end": "'",
           "patterns": [
             {
-              "name": "constant.character.escape.grain",
-              "match": "\\\\."
+              "include": "#string-escape"
             }
           ]
+        }
+      ]
+    },
+    "string-escape": {
+      "patterns": [
+        {
+          "name": "constant.character.escape.grain",
+          "match": "(\\\\\\d{1,3}|\\\\x[A-Fa-f0-9]{1,2}|\\\\u[A-Fa-f0-9]{4}|\\\\u\\{[A-Fa-f0-9]{1,6}\\}|\\\\.)"
         }
       ]
     },


### PR DESCRIPTION
Closes #6.

From our string tests:
![image](https://user-images.githubusercontent.com/7244034/103373381-c2e6e000-4aa2-11eb-9517-6fc79955be1e.png)
