### PR TITLE
chore: clean up 'and' keyword

### DIFF
--- a/editor-extensions/vscode/syntaxes/grain.json
+++ b/editor-extensions/vscode/syntaxes/grain.json
@@ -10,7 +10,7 @@
     "bindings": {
       "patterns": [
         {
-          "match": "\\b((?:let|and)\\b\\s*(?:rec\\b)?\\s*(?:mut\\b)?)\\b\\s*(?!rec|mut)([a-z]\\w*)\\s*(:.*?)?(=)(?=.*=>)",
+          "match": "\\b((?:let)\\b\\s*(?:rec\\b)?\\s*(?:mut\\b)?)\\b\\s*(?!rec|mut)([a-z]\\w*)\\s*(:.*?)?(=)(?=.*=>)",
           "captures": {
             "1": {
               "name": "storage.type.grain"
@@ -27,7 +27,7 @@
           }
         },
         {
-          "match": "\\b((?:let|and)\\b\\s*(?:rec\\b)?\\s*(?:mut\\b)?)\\b\\s*(?!rec|mut)([a-z]\\w*)\\s*(:.*?)?(=)(?=\\s*pattern\\b)",
+          "match": "\\b((?:let)\\b\\s*(?:rec\\b)?\\s*(?:mut\\b)?)\\b\\s*(?!rec|mut)([a-z]\\w*)\\s*(:.*?)?(=)(?=\\s*pattern\\b)",
           "captures": {
             "1": {
               "name": "storage.type.grain"
@@ -48,7 +48,7 @@
           }
         },
         {
-          "begin": "\\b((?:let|and)\\b\\s*(?:rec\\b)?\\s*(?:mut\\b)?)\\b\\s*(\\()",
+          "begin": "\\b((?:let)\\b\\s*(?:rec\\b)?\\s*(?:mut\\b)?)\\b\\s*(\\()",
           "end": "(\\))\\s*(:.*?)?(=)",
           "beginCaptures": {
             "1": { "name": "storage.type.grain" },
@@ -68,7 +68,7 @@
           "patterns": [{ "include": "#binding-destructure" }]
         },
         {
-          "match": "\\b((?:let|and)\\b\\s*(?:rec\\b)?\\s*(?:mut\\b)?)\\b\\s*(?!rec|mut)([a-z]\\w*)\\s*(:.*?)?(=)",
+          "match": "\\b((?:let)\\b\\s*(?:rec\\b)?\\s*(?:mut\\b)?)\\b\\s*(?!rec|mut)([a-z]\\w*)\\s*(:.*?)?(=)",
           "captures": {
             "1": {
               "name": "storage.type.grain"
@@ -93,7 +93,7 @@
           }
         },
         {
-          "match": "\\b((?:let|and)\\b\\s*(?:rec\\b)?\\s*(?:mut\\b)?)\\b\\s*(?!rec|mut)([a-z]\\w*)\\b\\s*(:.*)?",
+          "match": "\\b((?:let)\\b\\s*(?:rec\\b)?\\s*(?:mut\\b)?)\\b\\s*(?!rec|mut)([a-z]\\w*)\\b\\s*(:.*)?",
           "captures": {
             "1": {
               "name": "storage.type.grain"
@@ -830,7 +830,7 @@
     "keywords": {
       "patterns": [
         {
-          "match": "\\b(throw|let|rec|mut|and|record|enum|while|match|when|pattern|assert|fail|import|export|foreign|primitive|from|except|as)\\b",
+          "match": "\\b(throw|let|rec|mut|record|enum|while|match|when|pattern|assert|fail|import|export|foreign|primitive|from|except|as)\\b",
           "name": "keyword.control.grain"
         }
       ]


### PR DESCRIPTION
We haven't used this keyword for some time, and it breaks highlighting for valid uses of `and` as an identifier.