### PR TITLE
Fixes to get Packaged Grain working with Windows

### DIFF
--- a/editor-extensions/vscode/package.json
+++ b/editor-extensions/vscode/package.json
@@ -60,6 +60,12 @@
 				"path": "./syntaxes/grain-type.json"
 			}
 		],
+		"configurationDefaults": {
+			"[grain]": {
+				"files.eol": "\n",
+				"files.insertFinalNewline": true
+			}
+		},
 		"configuration": {
 			"type": "object",
 			"title": "Grain Language Server configuration",


### PR DESCRIPTION
When trying to use the Packaged Grain binaries as the LSP driver on Windows, I found a bunch of issues.
1. We don't want to append `.cmd` to the filename
2. We need to capitalize the drive letter otherwise it crashes
3. CRLF line feeds screw up the LSP line numbers

This fixes or paves over those issues.