### PR TITLE
fix: Floating-point number syntax highlighting

### DIFF
--- a/editor-extensions/vscode/syntaxes/grain.json
+++ b/editor-extensions/vscode/syntaxes/grain.json
@@ -642,11 +642,7 @@
     "number": {
       "patterns": [
         {
-          "match": "\\b(\\d[\\d_]*)\\.([\\d_]*)?[fdwW]?\\b",
-          "name": "constant.numeric.grain"
-        },
-        {
-          "match": "\\b\\.(\\d[\\d_]*)?[fdwW]?\\b",
+          "match": "\\b(\\d[\\d_]*)(\\.[\\d_]*)?([eE][+-]?\\d[\\d_]*)?[fdwW]?\\b",
           "name": "constant.numeric.grain"
         },
         {


### PR DESCRIPTION
Fixes #53 

Also simplified this into a single rule.

![image](https://user-images.githubusercontent.com/7244034/117556048-d991da80-b032-11eb-9984-4693077e2b21.png)
