### PR TITLE
fix: rational highlighting

### DIFF
--- a/editor-extensions/vscode/syntaxes/grain.json
+++ b/editor-extensions/vscode/syntaxes/grain.json
@@ -642,11 +642,11 @@
     "number": {
       "patterns": [
         {
-          "match": "\\b(\\d[\\d_]*)(\\.[\\d_]*)?([eE][+-]?\\d[\\d_]*)?[fdwW]?\\b",
+          "match": "\\b(\\d[\\d_]*)\\s*/\\s*(\\d[\\d_]*)\\b",
           "name": "constant.numeric.grain"
         },
         {
-          "match": "\\b(\\d[\\d_]*)\\s*/\\s*(\\d[\\d_]*)\\b",
+          "match": "\\b(\\d[\\d_]*)(\\.[\\d_]*)?([eE][+-]?\\d[\\d_]*)?[fdwW]?\\b",
           "name": "constant.numeric.grain"
         },
         {


### PR DESCRIPTION
The diff looks really weird, but I just swapped the order of these two rules. I broke this with my last change 🙈 

I've looked into adding tests for the grammar previously, and now I've added an issue for it in #57.