### PR TITLE
fix: No longer recommend \n for grain files

### DIFF
--- a/editor-extensions/vscode/package.json
+++ b/editor-extensions/vscode/package.json
@@ -62,7 +62,6 @@
     ],
     "configurationDefaults": {
       "[grain]": {
-        "files.eol": "\n",
         "files.insertFinalNewline": true
       }
     },


### PR DESCRIPTION
I think we missed this in the cleanup.