### PR TITLE
feat: Add completions for Grain Doc comments

### DIFF
--- a/editor-extensions/vscode/client/src/GrainDocCompletionProvider.ts
+++ b/editor-extensions/vscode/client/src/GrainDocCompletionProvider.ts
@@ -4,57 +4,61 @@ import * as vscode from "vscode";
 const defaultGrainDoc = new vscode.SnippetString(`/**\n  $0\n*/`);
 
 class GrainDocCompletionItem extends vscode.CompletionItem {
-	constructor(
-		public readonly document: vscode.TextDocument,
-		public readonly position: vscode.Position
-	) {
-		super('/** */', vscode.CompletionItemKind.Text);
-		this.detail = 'Grain Doc Comment'
-		this.sortText = '\0';
+  constructor(
+    public readonly document: vscode.TextDocument,
+    public readonly position: vscode.Position
+  ) {
+    super("/** */", vscode.CompletionItemKind.Text);
+    this.detail = "Grain Doc Comment";
+    this.sortText = "\0";
 
-		const line = document.lineAt(position.line).text;
-		const prefix = line.slice(0, position.character).match(/\/\**\s*$/);
-		const suffix = line.slice(position.character).match(/^\s*\**\//);
-		const start = position.translate(0, prefix ? -prefix[0].length : 0);
-		const range = new vscode.Range(start, position.translate(0, suffix ? suffix[0].length : 0));
-		this.range = { inserting: range, replacing: range };
-	}
+    const line = document.lineAt(position.line).text;
+    const prefix = line.slice(0, position.character).match(/\/\**\s*$/);
+    const suffix = line.slice(position.character).match(/^\s*\**\//);
+    const start = position.translate(0, prefix ? -prefix[0].length : 0);
+    const range = new vscode.Range(
+      start,
+      position.translate(0, suffix ? suffix[0].length : 0)
+    );
+    this.range = { inserting: range, replacing: range };
+  }
 }
 
-export class GrainDocCompletionProvider implements vscode.CompletionItemProvider {
+export class GrainDocCompletionProvider
+  implements vscode.CompletionItemProvider {
   constructor() {}
 
   public async provideCompletionItems(
-		document: vscode.TextDocument,
-		position: vscode.Position,
-		token: vscode.CancellationToken
-	): Promise<vscode.CompletionItem[] | undefined> {
-		if (!this.isPotentiallyValidDocCompletionPosition(document, position)) {
-			return undefined;
-		}
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    token: vscode.CancellationToken
+  ): Promise<vscode.CompletionItem[] | undefined> {
+    if (!this.isPotentiallyValidDocCompletionPosition(document, position)) {
+      return undefined;
+    }
 
-		const item = new GrainDocCompletionItem(document, position);
+    const item = new GrainDocCompletionItem(document, position);
 
     // TODO: Get param and returns details from `grain lsp`
     item.insertText = defaultGrainDoc;
 
-		return [item];
+    return [item];
   }
 
   private isPotentiallyValidDocCompletionPosition(
-		document: vscode.TextDocument,
-		position: vscode.Position
-	): boolean {
-		// Only show the GrainDoc completion when the everything before the cursor is whitespace
-		// or could be the opening of a comment
-		const line = document.lineAt(position.line).text;
-		const prefix = line.slice(0, position.character);
-		if (!/^\s*$|\/\*\*\s*$|^\s*\/\*\*+\s*$/.test(prefix)) {
-			return false;
-		}
+    document: vscode.TextDocument,
+    position: vscode.Position
+  ): boolean {
+    // Only show the GrainDoc completion when the everything before the cursor is whitespace
+    // or could be the opening of a comment
+    const line = document.lineAt(position.line).text;
+    const prefix = line.slice(0, position.character);
+    if (!/^\s*$|\/\*\*\s*$|^\s*\/\*\*+\s*$/.test(prefix)) {
+      return false;
+    }
 
-		// And everything after is possibly a closing comment or more whitespace
-		const suffix = line.slice(position.character);
-		return /^\s*(\*+\/)?\s*$/.test(suffix);
-	}
+    // And everything after is possibly a closing comment or more whitespace
+    const suffix = line.slice(position.character);
+    return /^\s*(\*+\/)?\s*$/.test(suffix);
+  }
 }

--- a/editor-extensions/vscode/client/src/GrainDocCompletionProvider.ts
+++ b/editor-extensions/vscode/client/src/GrainDocCompletionProvider.ts
@@ -1,6 +1,6 @@
 // Based on https://github.com/microsoft/vscode/blob/94c9ea46838a9a619aeafb7e8afd1170c967bb55/extensions/typescript-language-features/src/languageFeatures/jsDocCompletions.ts
 import * as vscode from "vscode";
-import { LanguageClient } from "vscode-languageclient"
+import { LanguageClient } from "vscode-languageclient";
 
 const defaultGrainDoc = new vscode.SnippetString(`/**\n * $0\n */`);
 

--- a/editor-extensions/vscode/client/src/GrainDocCompletionProvider.ts
+++ b/editor-extensions/vscode/client/src/GrainDocCompletionProvider.ts
@@ -1,0 +1,60 @@
+// Based on https://github.com/microsoft/vscode/blob/94c9ea46838a9a619aeafb7e8afd1170c967bb55/extensions/typescript-language-features/src/languageFeatures/jsDocCompletions.ts
+import * as vscode from "vscode";
+
+const defaultGrainDoc = new vscode.SnippetString(`/**\n  $0\n*/`);
+
+class GrainDocCompletionItem extends vscode.CompletionItem {
+	constructor(
+		public readonly document: vscode.TextDocument,
+		public readonly position: vscode.Position
+	) {
+		super('/** */', vscode.CompletionItemKind.Text);
+		this.detail = 'Grain Doc Comment'
+		this.sortText = '\0';
+
+		const line = document.lineAt(position.line).text;
+		const prefix = line.slice(0, position.character).match(/\/\**\s*$/);
+		const suffix = line.slice(position.character).match(/^\s*\**\//);
+		const start = position.translate(0, prefix ? -prefix[0].length : 0);
+		const range = new vscode.Range(start, position.translate(0, suffix ? suffix[0].length : 0));
+		this.range = { inserting: range, replacing: range };
+	}
+}
+
+export class GrainDocCompletionProvider implements vscode.CompletionItemProvider {
+  constructor() {}
+
+  public async provideCompletionItems(
+		document: vscode.TextDocument,
+		position: vscode.Position,
+		token: vscode.CancellationToken
+	): Promise<vscode.CompletionItem[] | undefined> {
+		if (!this.isPotentiallyValidDocCompletionPosition(document, position)) {
+			return undefined;
+		}
+
+		const item = new GrainDocCompletionItem(document, position);
+
+    // TODO: Get param and returns details from `grain lsp`
+    item.insertText = defaultGrainDoc;
+
+		return [item];
+  }
+
+  private isPotentiallyValidDocCompletionPosition(
+		document: vscode.TextDocument,
+		position: vscode.Position
+	): boolean {
+		// Only show the GrainDoc completion when the everything before the cursor is whitespace
+		// or could be the opening of a comment
+		const line = document.lineAt(position.line).text;
+		const prefix = line.slice(0, position.character);
+		if (!/^\s*$|\/\*\*\s*$|^\s*\/\*\*+\s*$/.test(prefix)) {
+			return false;
+		}
+
+		// And everything after is possibly a closing comment or more whitespace
+		const suffix = line.slice(position.character);
+		return /^\s*(\*+\/)?\s*$/.test(suffix);
+	}
+}

--- a/editor-extensions/vscode/client/src/GrainDocCompletionProvider.ts
+++ b/editor-extensions/vscode/client/src/GrainDocCompletionProvider.ts
@@ -1,7 +1,8 @@
 // Based on https://github.com/microsoft/vscode/blob/94c9ea46838a9a619aeafb7e8afd1170c967bb55/extensions/typescript-language-features/src/languageFeatures/jsDocCompletions.ts
 import * as vscode from "vscode";
+import { LanguageClient } from "vscode-languageclient"
 
-const defaultGrainDoc = new vscode.SnippetString(`/**\n  $0\n*/`);
+const defaultGrainDoc = new vscode.SnippetString(`/**\n * $0\n */`);
 
 class GrainDocCompletionItem extends vscode.CompletionItem {
   constructor(
@@ -26,7 +27,7 @@ class GrainDocCompletionItem extends vscode.CompletionItem {
 
 export class GrainDocCompletionProvider
   implements vscode.CompletionItemProvider {
-  constructor() {}
+  constructor(readonly client: LanguageClient) {}
 
   public async provideCompletionItems(
     document: vscode.TextDocument,

--- a/editor-extensions/vscode/client/src/extension.ts
+++ b/editor-extensions/vscode/client/src/extension.ts
@@ -16,12 +16,14 @@ import {
 } from "vscode-languageclient";
 
 import { CodelensProvider } from "./CodelensProvider";
+import { GrainDocCompletionProvider } from "./GrainDocCompletionProvider";
 
 let client: LanguageClient;
 
 let disposables: Disposable[] = [];
 
 let codelensProvider: CodelensProvider;
+let grainDocCompletionProvider: GrainDocCompletionProvider;
 
 export function activate(context: ExtensionContext) {
   // The server is implemented in node
@@ -67,6 +69,9 @@ export function activate(context: ExtensionContext) {
     // until LSP 3.16.0 arrives
     codelensProvider = new CodelensProvider(client);
     languages.registerCodeLensProvider("grain", codelensProvider);
+
+    grainDocCompletionProvider = new GrainDocCompletionProvider();
+    languages.registerCompletionItemProvider("grain", grainDocCompletionProvider, "*")
 
     codelensProvider.triggerRefresh();
     client.onNotification("grainlsp/lensesLoaded", (files: Array<String>) => {

--- a/editor-extensions/vscode/client/src/extension.ts
+++ b/editor-extensions/vscode/client/src/extension.ts
@@ -70,7 +70,7 @@ export function activate(context: ExtensionContext) {
     codelensProvider = new CodelensProvider(client);
     languages.registerCodeLensProvider("grain", codelensProvider);
 
-    grainDocCompletionProvider = new GrainDocCompletionProvider();
+    grainDocCompletionProvider = new GrainDocCompletionProvider(client);
     languages.registerCompletionItemProvider(
       "grain",
       grainDocCompletionProvider,

--- a/editor-extensions/vscode/client/src/extension.ts
+++ b/editor-extensions/vscode/client/src/extension.ts
@@ -71,7 +71,11 @@ export function activate(context: ExtensionContext) {
     languages.registerCodeLensProvider("grain", codelensProvider);
 
     grainDocCompletionProvider = new GrainDocCompletionProvider();
-    languages.registerCompletionItemProvider("grain", grainDocCompletionProvider, "*")
+    languages.registerCompletionItemProvider(
+      "grain",
+      grainDocCompletionProvider,
+      "*"
+    );
 
     codelensProvider.triggerRefresh();
     client.onNotification("grainlsp/lensesLoaded", (files: Array<String>) => {


### PR DESCRIPTION
Almost a direct ripoff of the JsDoc implementation in the official vscode typescript extension. This can be improved to automatically fill out the `@param` and `@returns` in the future, but I just want it to auto complete the comment start/end right now.