### PR TITLE
fix: proper token types for storage keywords

### DIFF
--- a/editor-extensions/vscode/syntaxes/grain.json
+++ b/editor-extensions/vscode/syntaxes/grain.json
@@ -826,8 +826,12 @@
     "keywords": {
       "patterns": [
         {
-          "match": "\\b(throw|let|rec|mut|record|enum|while|for|continue|break|match|when|pattern|assert|fail|import|export|foreign|primitive|from|except|as)\\b",
+          "match": "\\b(throw|while|for|continue|break|match|when|pattern|assert|fail|import|export|from|except|as)\\b",
           "name": "keyword.control.grain"
+        },
+        {
+          "match": "\\b(let|rec|mut|record|enum|foreign|primitive)\\b",
+          "name": "storage.type.grain"
         }
       ]
     },


### PR DESCRIPTION
This makes storage tokens like `let` always highlight as a storage token, and not randomly as a control token.