### PR TITLE
feat(docblock): Continue to add * inside doc comments after return

### DIFF
--- a/editor-extensions/vscode/language-configuration.json
+++ b/editor-extensions/vscode/language-configuration.json
@@ -37,14 +37,16 @@
       // e.g. /** ...|
       "beforeText": "^\\s*\\/\\*\\*(?!\\/)([^\\*]|\\*(?!\\/))*$",
       "action": { "indent": "none", "appendText": " * " }
-    }, {
+    },
+    {
       // e.g.  * ...|
       "beforeText": "^(\\t|(\\ ))*\\ \\*(\\ ([^\\*]|\\*(?!\\/))*)?$",
       "action": { "indent": "none", "appendText": "* " }
-    }, {
+    },
+    {
       // e.g.  */|
       "beforeText": "^(\\t|(\\ ))*\\ \\*\\/\\s*$",
       "action": { "indent": "none", "removeText": 1 }
-    },
+    }
   ]
 }

--- a/editor-extensions/vscode/language-configuration.json
+++ b/editor-extensions/vscode/language-configuration.json
@@ -24,5 +24,27 @@
     ["(", ")"],
     ["\"", "\""],
     ["'", "'"]
+  ],
+  // Based on https://github.com/kevb34ns/auto-comment-blocks/blob/24f8ebc584e3e77d6a116a5a03a80c55008b44a3/src/rules.ts#L7-L40
+  "onEnterRules": [
+    {
+      // e.g. /** | */
+      "beforeText": "^\\s*\\/\\*\\*(?!\\/)([^\\*]|\\*(?!\\/))*$",
+      "afterText": "^\\s*\\*\\/$",
+      "action": { "indent": "indentOutdent", "appendText": " * " }
+    },
+    {
+      // e.g. /** ...|
+      "beforeText": "^\\s*\\/\\*\\*(?!\\/)([^\\*]|\\*(?!\\/))*$",
+      "action": { "indent": "none", "appendText": " * " }
+    }, {
+      // e.g.  * ...|
+      "beforeText": "^(\\t|(\\ ))*\\ \\*(\\ ([^\\*]|\\*(?!\\/))*)?$",
+      "action": { "indent": "none", "appendText": "* " }
+    }, {
+      // e.g.  */|
+      "beforeText": "^(\\t|(\\ ))*\\ \\*\\/\\s*$",
+      "action": { "indent": "none", "removeText": 1 }
+    },
   ]
 }


### PR DESCRIPTION
This uses a technique from https://github.com/kevb34ns/auto-comment-blocks to continue adding ` * ` when you hit return within a codeblock (thanks @marcusroberts for linking that extension previously).