### PR TITLE
chore: Fix some nits

### DIFF
--- a/editor-extensions/vscode/.npmrc
+++ b/editor-extensions/vscode/.npmrc
@@ -1,0 +1,1 @@
+package-lock=true

--- a/editor-extensions/vscode/package.json
+++ b/editor-extensions/vscode/package.json
@@ -119,6 +119,7 @@
     "postinstall": "cd client && npm install && cd ../server && npm install && cd ..",
     "test": "sh ./scripts/e2e.sh",
     "vscode:prepublish": "npm run compile",
+    "package": "vsce package",
     "test-compile": "tsc -p ./",
     "format": "prettier --write .",
     "check-format": "prettier --check .",


### PR DESCRIPTION
All my usage of the `npm` command shuts off package-lock, so we should have an npmrc to enable it.

I also added a package command I've been using for my development workflow.