### PR TITLE
feat: Search for a variety of grain CLIs in PATH

### DIFF
--- a/editor-extensions/vscode/package-lock.json
+++ b/editor-extensions/vscode/package-lock.json
@@ -9,12 +9,14 @@
       "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
-        "vscode-languageclient": "^8.0.1"
+        "vscode-languageclient": "^8.0.1",
+        "which": "^2.0.2"
       },
       "devDependencies": {
         "@types/mocha": "^9.1.1",
         "@types/node": "^12.12.0",
         "@types/vscode": "1.67.0",
+        "@types/which": "^2.0.1",
         "@typescript-eslint/parser": "^5.25.0",
         "@vscode/test-electron": "^2.1.3",
         "esbuild": "^0.14.42",
@@ -129,6 +131,12 @@
       "version": "1.67.0",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.67.0.tgz",
       "integrity": "sha512-GH8BDf8cw9AC9080uneJfulhSa7KHSMI2s/CyKePXoGNos9J486w2V4YKoeNUqIEkW4hKoEAWp6/cXTwyGj47g==",
+      "dev": true
+    },
+    "node_modules/@types/which": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.1.tgz",
+      "integrity": "sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ==",
       "dev": true
     },
     "node_modules/@typescript-eslint/parser": {
@@ -2230,8 +2238,7 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -3753,7 +3760,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -4050,6 +4056,12 @@
       "version": "1.67.0",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.67.0.tgz",
       "integrity": "sha512-GH8BDf8cw9AC9080uneJfulhSa7KHSMI2s/CyKePXoGNos9J486w2V4YKoeNUqIEkW4hKoEAWp6/cXTwyGj47g==",
+      "dev": true
+    },
+    "@types/which": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.1.tgz",
+      "integrity": "sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ==",
       "dev": true
     },
     "@typescript-eslint/parser": {
@@ -5489,8 +5501,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -6631,7 +6642,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/editor-extensions/vscode/package.json
+++ b/editor-extensions/vscode/package.json
@@ -78,8 +78,7 @@
         "grain.cliPath": {
           "scope": "resource",
           "type": "string",
-          "default": "grain",
-          "description": "Path to the grain cli"
+          "description": "Absolute path to the grain CLI (detected in PATH if not specified)"
         },
         "grain.enableLSP": {
           "scope": "resource",
@@ -114,12 +113,14 @@
     "deploy": "vsce publish && ovsx publish"
   },
   "dependencies": {
-    "vscode-languageclient": "^8.0.1"
+    "vscode-languageclient": "^8.0.1",
+    "which": "^2.0.2"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",
     "@types/node": "^12.12.0",
     "@types/vscode": "1.67.0",
+    "@types/which": "^2.0.1",
     "@typescript-eslint/parser": "^5.25.0",
     "@vscode/test-electron": "^2.1.3",
     "esbuild": "^0.14.42",

--- a/editor-extensions/vscode/tsconfig.json
+++ b/editor-extensions/vscode/tsconfig.json
@@ -5,7 +5,8 @@
     "lib": ["ES2022"],
     "outDir": "out",
     "rootDir": "src",
-    "sourceMap": true
+    "sourceMap": true,
+    "esModuleInterop": true
   },
   "include": ["src/*"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
Closes #48
Closes #88 

This uses the `which` package from npm to locate grain executables within a user's path. I found a weird edge case in testing on Windows related to capitalized `.EXE` that I also "fixed" with a workaround.