### PR TITLE
feat!: Replace grainfind with cliFlags setting

### DIFF
--- a/editor-extensions/vscode/package.json
+++ b/editor-extensions/vscode/package.json
@@ -79,6 +79,11 @@
       "type": "object",
       "title": "Grain Language Server configuration",
       "properties": {
+        "grain.cliFlags": {
+          "scope": "resource",
+          "type": "string",
+          "description": "Space-separated list of flags to pass to the grain CLI"
+        },
         "grain.cliPath": {
           "scope": "resource",
           "type": "string",

--- a/editor-extensions/vscode/src/extension.ts
+++ b/editor-extensions/vscode/src/extension.ts
@@ -98,13 +98,13 @@ function getOuterMostWorkspaceFolder(folder: WorkspaceFolder): WorkspaceFolder {
 function getLspCommand(uri: Uri) {
   let config = workspace.getConfiguration("grain", uri);
 
-  let lspEnabled: boolean = config.get("enableLSP");
+  let lspEnabled = config.get<boolean>("enableLSP");
 
   if (!lspEnabled) {
     return;
   }
 
-  let command: string = config.get("cliPath") || findGrain();
+  let command = config.get<string | undefined>("cliPath") || findGrain();
   // For some reason, if you specify a capitalized EXE extension for our pkg binary,
   // it crashes the LSP so we just lowercase any .EXE ending in the command
   command = command.replace(/\.EXE$/, ".exe");


### PR DESCRIPTION
Closes #50
Closes #112 

This replaces the `grainfind.js` workaround with an option to specify flags passed to `grain lsp`. I tested this by changing `cliPath` to my local pkg executable, which outputs the stdlib into `./target/`, and then setting `cliFlags` to `--stdlib /abs/path/to/grain/stdlib` and verifying that it output the wasm files into the stdlib inside of grain.