### PR TITLE
fix: Avoid handling output scheme messages

### DIFF
--- a/editor-extensions/vscode/src/extension.ts
+++ b/editor-extensions/vscode/src/extension.ts
@@ -281,6 +281,12 @@ async function didOpenTextDocument(
       }
     };
   } else {
+    // We only want to handle `file:` and `untitled:` schemes because
+    //vscode sends `output:` schemes for markdown responses from our LSP
+    if (uri.scheme !== "file" && uri.scheme !== "untitled") {
+      return Disposable.from();
+    }
+
     // Each file outside of a workspace gets it's own client
     await addFileClient(uri);
 


### PR DESCRIPTION
Marcus and I noticed that the LSP was being spammed with messages. I traced it down to this code path and found that we were spinning up an LSP server to handle the `output:` scheme, which we don't want to do, since those are sent by our LSP.