### PR TITLE
chore: Upgrade to beta of vscode-languageclient

### DIFF
--- a/editor-extensions/vscode/package-lock.json
+++ b/editor-extensions/vscode/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
-        "vscode-languageclient": "^8.0.1",
+        "vscode-languageclient": "^8.0.2-next.4",
         "which": "^2.0.2"
       },
       "devDependencies": {
@@ -3722,39 +3722,39 @@
       }
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.1.tgz",
-      "integrity": "sha512-N/WKvghIajmEvXpatSzvTvOIz61ZSmOSa4BRA4pTLi+1+jozquQKP/MkaylP9iB68k73Oua1feLQvH3xQuigiQ==",
+      "version": "8.0.2-next.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2-next.1.tgz",
+      "integrity": "sha512-sbbvGSWja7NVBLHPGawtgezc8DHYJaP4qfr/AaJiyDapWcSFtHyPtm18+LnYMLTmB7bhOUW/lf5PeeuLpP6bKA==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageclient": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.1.tgz",
-      "integrity": "sha512-9XoE+HJfaWvu7Y75H3VmLo5WLCtsbxEgEhrLPqwt7eyoR49lUIyyrjb98Yfa50JCMqF2cePJAEVI6oe2o1sIhw==",
+      "version": "8.0.2-next.4",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.2-next.4.tgz",
+      "integrity": "sha512-j9BEiCYMN9IoKwYdk9iickV6WNPVGPoVO11SMdoxFnWPIT3y5UAe3qf/WsfA9OdklAIaxxYasfgyKCpBjSPNuw==",
       "dependencies": {
         "minimatch": "^3.0.4",
         "semver": "^7.3.5",
-        "vscode-languageserver-protocol": "3.17.1"
+        "vscode-languageserver-protocol": "3.17.2-next.5"
       },
       "engines": {
         "vscode": "^1.67.0"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.1.tgz",
-      "integrity": "sha512-BNlAYgQoYwlSgDLJhSG+DeA8G1JyECqRzM2YO6tMmMji3Ad9Mw6AW7vnZMti90qlAKb0LqAlJfSVGEdqMMNzKg==",
+      "version": "3.17.2-next.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2-next.5.tgz",
+      "integrity": "sha512-UlH+QL4Q4lX94of/UPDDwwWIkd8w7dtMW4khzvEDUoykiG9tba0iG6V0bAiv8XVpnBIUYjL2FNFiL3zl+TY1Sw==",
       "dependencies": {
-        "vscode-jsonrpc": "8.0.1",
-        "vscode-languageserver-types": "3.17.1"
+        "vscode-jsonrpc": "8.0.2-next.1",
+        "vscode-languageserver-types": "3.17.2-next.2"
       }
     },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.1.tgz",
-      "integrity": "sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ=="
+      "version": "3.17.2-next.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2-next.2.tgz",
+      "integrity": "sha512-TiAkLABgqkVWdAlC3XlOfdhdjIAdVU4YntPUm9kKGbXr+MGwpVnKz2KZMNBcvG0CFx8Hi8qliL0iq+ndPB720w=="
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -6610,33 +6610,33 @@
       }
     },
     "vscode-jsonrpc": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.1.tgz",
-      "integrity": "sha512-N/WKvghIajmEvXpatSzvTvOIz61ZSmOSa4BRA4pTLi+1+jozquQKP/MkaylP9iB68k73Oua1feLQvH3xQuigiQ=="
+      "version": "8.0.2-next.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2-next.1.tgz",
+      "integrity": "sha512-sbbvGSWja7NVBLHPGawtgezc8DHYJaP4qfr/AaJiyDapWcSFtHyPtm18+LnYMLTmB7bhOUW/lf5PeeuLpP6bKA=="
     },
     "vscode-languageclient": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.1.tgz",
-      "integrity": "sha512-9XoE+HJfaWvu7Y75H3VmLo5WLCtsbxEgEhrLPqwt7eyoR49lUIyyrjb98Yfa50JCMqF2cePJAEVI6oe2o1sIhw==",
+      "version": "8.0.2-next.4",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.2-next.4.tgz",
+      "integrity": "sha512-j9BEiCYMN9IoKwYdk9iickV6WNPVGPoVO11SMdoxFnWPIT3y5UAe3qf/WsfA9OdklAIaxxYasfgyKCpBjSPNuw==",
       "requires": {
         "minimatch": "^3.0.4",
         "semver": "^7.3.5",
-        "vscode-languageserver-protocol": "3.17.1"
+        "vscode-languageserver-protocol": "3.17.2-next.5"
       }
     },
     "vscode-languageserver-protocol": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.1.tgz",
-      "integrity": "sha512-BNlAYgQoYwlSgDLJhSG+DeA8G1JyECqRzM2YO6tMmMji3Ad9Mw6AW7vnZMti90qlAKb0LqAlJfSVGEdqMMNzKg==",
+      "version": "3.17.2-next.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2-next.5.tgz",
+      "integrity": "sha512-UlH+QL4Q4lX94of/UPDDwwWIkd8w7dtMW4khzvEDUoykiG9tba0iG6V0bAiv8XVpnBIUYjL2FNFiL3zl+TY1Sw==",
       "requires": {
-        "vscode-jsonrpc": "8.0.1",
-        "vscode-languageserver-types": "3.17.1"
+        "vscode-jsonrpc": "8.0.2-next.1",
+        "vscode-languageserver-types": "3.17.2-next.2"
       }
     },
     "vscode-languageserver-types": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.1.tgz",
-      "integrity": "sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ=="
+      "version": "3.17.2-next.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2-next.2.tgz",
+      "integrity": "sha512-TiAkLABgqkVWdAlC3XlOfdhdjIAdVU4YntPUm9kKGbXr+MGwpVnKz2KZMNBcvG0CFx8Hi8qliL0iq+ndPB720w=="
     },
     "which": {
       "version": "2.0.2",

--- a/editor-extensions/vscode/package.json
+++ b/editor-extensions/vscode/package.json
@@ -122,7 +122,7 @@
     "deploy": "vsce publish && ovsx publish"
   },
   "dependencies": {
-    "vscode-languageclient": "^8.0.1",
+    "vscode-languageclient": "^8.0.2-next.4",
     "which": "^2.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This is currently in the testing phase for me (locally), but I think we **need** to ship this with the vscode extension due to out-of-order messages.

This version solves https://github.com/microsoft/vscode-languageserver-node/issues/968