### PR TITLE
fix: Properly highlight true/false in pattern matching

### DIFF
--- a/editor-extensions/vscode/syntaxes/grain.json
+++ b/editor-extensions/vscode/syntaxes/grain.json
@@ -1084,6 +1084,7 @@
                 "1": { "name": "punctuation.definition.parameters.grain" }
               },
               "patterns": [
+                { "include": "#constant" },
                 {
                   "match": "\\b([a-z]\\w*)\\b",
                   "captures": {
@@ -1109,6 +1110,7 @@
             }
           ]
         },
+        { "include": "#constant" },
         {
           "match": "\\b([a-z]\\w*)\\b",
           "captures": {
@@ -1135,8 +1137,7 @@
         },
         { "include": "#type-destructor-tuple" },
         { "include": "#type-destructor-record" },
-        { "include": "#type-destructor-list" },
-        { "include": "#constant" }
+        { "include": "#type-destructor-list" }
       ]
     },
     "pattern-variant": {


### PR DESCRIPTION
Closes #102 

<img width="205" alt="image" src="https://user-images.githubusercontent.com/7244034/172081329-35d97de6-b5b1-4b24-9e91-d99f37b2280d.png">
