### PR TITLE
fix: Only highlight valid string escapes

### DIFF
--- a/editor-extensions/vscode/syntaxes/grain.json
+++ b/editor-extensions/vscode/syntaxes/grain.json
@@ -829,7 +829,11 @@
       "patterns": [
         {
           "name": "constant.character.escape.grain",
-          "match": "(\\\\\\d{1,3}|\\\\x[A-Fa-f0-9]{1,2}|\\\\u[A-Fa-f0-9]{4}|\\\\u\\{[A-Fa-f0-9]{1,6}\\}|\\\\.)"
+          "match": "(\\\\\\d{1,3}|\\\\x[A-Fa-f0-9]{1,2}|\\\\u[A-Fa-f0-9]{4}|\\\\u\\{[A-Fa-f0-9]{1,6}\\}|\\\\[bftvrn'\"\\\\])"
+        },
+        {
+          "name": "invalid.illegal.grain",
+          "match": "\\\\."
         }
       ]
     },


### PR DESCRIPTION
Also made it highlight invalid ones.
<img width="837" alt="image" src="https://user-images.githubusercontent.com/7244034/172082748-80c969e8-c2be-47c8-b866-59a591a333e6.png">

Closes #73 