### PR TITLE
fix: Adjust icon size

### DIFF
--- a/editor-extensions/vscode/icons/grain_shorthand_color.svg
+++ b/editor-extensions/vscode/icons/grain_shorthand_color.svg
@@ -1,4 +1,4 @@
-<svg width="64" height="68" viewBox="0 0 64 68" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="64" height="68" viewBox="-22 -14 84 88" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M32.1378 0L20.6406 23.7578L32.3148 33.9297L43.6438 23.7578L32.1378 0Z" fill="#FAA520"/>
 <path d="M0.89393 11.7734L0 40.4148L32.3054 68.0002L48.5201 53.8072L0.89393 11.7734Z" fill="#F78F28"/>
 <path d="M63.9998 40.4235V11.439L35.0488 37.0006L51.6972 51.1057L63.9998 40.4235Z" fill="#E18026"/>


### PR DESCRIPTION
This PR adjusts the icon size to better match other vscode icons. 

Before:
<img width="186" alt="image" src="https://user-images.githubusercontent.com/7244034/173238599-223f999c-5b0c-409e-8f6c-6c3fb684e564.png">

After:
<img width="204" alt="image" src="https://user-images.githubusercontent.com/7244034/173238613-550f2c89-fb79-4ede-a5a4-f8ea56e9c26e.png">
