### PR TITLE
fix: Highlight match keyword correctly

### DIFF
--- a/editor-extensions/vscode/syntaxes/grain.json
+++ b/editor-extensions/vscode/syntaxes/grain.json
@@ -1219,7 +1219,7 @@
               "begin": "\\b(match)\\b\\s*(\\()",
               "end": "(\\))",
               "beginCaptures": {
-                "1": { "name": "keyword.operator.grain" },
+                "1": { "name": "keyword.control.grain" },
                 "2": { "name": "punctuation.definition.parameters.begin.grain" }
               },
               "endCaptures": {
@@ -1236,7 +1236,7 @@
         {
           "match": "\\b(match)\\b\\s*(?=\\()",
           "captures": {
-            "1": { "name": "keyword.operator.grain" }
+            "1": { "name": "keyword.control.grain" }
           }
         }
       ]


### PR DESCRIPTION
Here's an example, although I don't know if it's helpful if you're not using my same color theme:

<img width="383" alt="image" src="https://user-images.githubusercontent.com/7244034/173259146-818a84f3-d678-4aff-a968-2592c2f466fd.png">
