### PR TITLE
fix: Highlight module scoped types properly

### DIFF
--- a/editor-extensions/vscode/syntaxes/grain.json
+++ b/editor-extensions/vscode/syntaxes/grain.json
@@ -221,7 +221,7 @@
           ]
         },
         {
-          "match": "->",
+          "match": "(->|\\.)",
           "name": "keyword.operator.grain"
         },
         { "include": "#type-args" },
@@ -239,28 +239,28 @@
           "patterns": [{ "include": "#type" }]
         },
         {
-          "match": "(->)\\s*(\\w+(<.*?>)?)",
+          "match": "(->)\\s*(\\w+(\\.\\w+)*(<.*?>)?)",
           "captures": {
             "1": { "name": "keyword.operator.grain" },
             "2": { "patterns": [{ "include": "#type" }] }
           }
         },
         {
-          "match": "(:)\\s*(\\w+(<.*?>)?\\s*->\\s*\\w+(<.*?>)?)",
+          "match": "(:)\\s*(\\w+(\\.\\w+)*(<.*?>)?\\s*->\\s*\\w+(<.*?>)?)",
           "captures": {
             "1": { "name": "keyword.operator.grain" },
             "2": { "patterns": [{ "include": "#type" }] }
           }
         },
         {
-          "match": "(:)\\s*(\\w+(<.*?>)?\\s*->\\s*\\(.*\\))",
+          "match": "(:)\\s*(\\w+(\\.\\w+)*(<.*?>)?\\s*->\\s*\\(.*\\))",
           "captures": {
             "1": { "name": "keyword.operator.grain" },
             "2": { "patterns": [{ "include": "#type" }] }
           }
         },
         {
-          "match": "(:)\\s*(\\w+(<.*?>)?)",
+          "match": "(:)\\s*(\\w+(\\.\\w+)*(<.*?>)?)",
           "captures": {
             "1": { "name": "keyword.operator.grain" },
             "2": { "patterns": [{ "include": "#type" }] }


### PR DESCRIPTION
<img width="488" alt="image" src="https://user-images.githubusercontent.com/7244034/173270924-3efdf78e-7ca0-424d-a19c-6df7a38791c4.png">

Will also support future extensions:

<img width="329" alt="image" src="https://user-images.githubusercontent.com/7244034/173271002-07f080ae-f50c-4ab8-b4ac-afbcbb55aa6b.png">
