### PR TITLE
fix: Correctly highlight function type annotations in type vectors

### DIFF
--- a/editor-extensions/vscode/syntaxes/grain.json
+++ b/editor-extensions/vscode/syntaxes/grain.json
@@ -168,7 +168,7 @@
         },
         {
           "begin": "(\\b[A-Z]\\w*\\b)\\s*(<)",
-          "end": "(>)",
+          "end": "((?<!-)>)",
           "beginCaptures": {
             "1": {
               "name": "entity.name.type.grain"
@@ -179,8 +179,7 @@
             "1": { "name": "punctuation.definition.parameters.grain" }
           },
           "patterns": [
-            { "include": "#type-constructor" },
-            { "include": "#type-var" },
+            { "include": "#type" },
             {
               "match": ",",
               "name": "punctuation.definition.parameters.grain"
@@ -239,28 +238,28 @@
           "patterns": [{ "include": "#type" }]
         },
         {
-          "match": "(->)\\s*(\\w+(\\.\\w+)*(<.*?>)?)",
+          "match": "(->)\\s*(\\w+(\\.\\w+)*(<.*?(?<!-)>)?)",
           "captures": {
             "1": { "name": "keyword.operator.grain" },
             "2": { "patterns": [{ "include": "#type" }] }
           }
         },
         {
-          "match": "(:)\\s*(\\w+(\\.\\w+)*(<.*?>)?\\s*->\\s*\\w+(<.*?>)?)",
+          "match": "(:)\\s*(\\w+(\\.\\w+)*(<.*?(?<!-)>)?\\s*->\\s*\\w+(<.*?(?<!-)>)?)",
           "captures": {
             "1": { "name": "keyword.operator.grain" },
             "2": { "patterns": [{ "include": "#type" }] }
           }
         },
         {
-          "match": "(:)\\s*(\\w+(\\.\\w+)*(<.*?>)?\\s*->\\s*\\(.*\\))",
+          "match": "(:)\\s*(\\w+(\\.\\w+)*(<.*?(?<!-)>)?\\s*->\\s*\\(.*\\))",
           "captures": {
             "1": { "name": "keyword.operator.grain" },
             "2": { "patterns": [{ "include": "#type" }] }
           }
         },
         {
-          "match": "(:)\\s*(\\w+(\\.\\w+)*(<.*?>)?)",
+          "match": "(:)\\s*(\\w+(\\.\\w+)*(<.*?(?<!-)>)?)",
           "captures": {
             "1": { "name": "keyword.operator.grain" },
             "2": { "patterns": [{ "include": "#type" }] }


### PR DESCRIPTION
Before:
<img width="330" alt="image" src="https://user-images.githubusercontent.com/7244034/179425351-8a09b750-1a3c-4c38-ae1c-9bd70cf5b3c6.png">

After:
<img width="327" alt="image" src="https://user-images.githubusercontent.com/7244034/179425360-dc88b04d-1917-49d5-98db-56b9588fd2ce.png">
