### PR TITLE
feat: Support custom operators

### DIFF
--- a/editor-extensions/vscode/syntaxes/grain.json
+++ b/editor-extensions/vscode/syntaxes/grain.json
@@ -625,10 +625,20 @@
     "identifier": {
       "patterns": [
         {
-          "match": "(\\bis(nt)?\\b|=|(\\+|-|\\*|\\/)=|\\+|-|\\*|\\/|%|<=|>=|<|>|==|!=|:=|\\!|&&|&|\\|\\||\\||\\^|\\.\\.\\.|\\.)",
-          "captures": {
-            "1": { "name": "keyword.operator.grain" }
-          }
+          "match": "(==|!=|<|>|\\^|\\+|-|\\*|%|/|&|\\||\\?\\?)[$&\\*/\\+\\-=><\\^\\|\\!\\?%:\\.]*",
+          "name": "keyword.operator.grain"
+        },
+        {
+          "match": "(<=|>=|<|>|==|!=|:=|\\!)",
+          "name": "keyword.operator.grain"
+        },
+        {
+          "match": "\\bis(nt)?\\b",
+          "name": "keyword.operator.grain"
+        },
+        {
+          "match": "(\\.\\.\\.|\\.)",
+          "name": "keyword.operator.grain"
         },
         {
           "match": "\\b_[A-Z0-9_]+\\b",


### PR DESCRIPTION
Smoke test from the Grain test suite:

<img width="204" alt="image" src="https://user-images.githubusercontent.com/7244034/219905549-8c32293e-fb72-4c96-abd3-36886c6a744a.png">

Closes #144 
Closes #145 