### PR TITLE
chore: remove graindoc `next` from highlighting

### DIFF
--- a/editor-extensions/vscode/syntaxes/grain.json
+++ b/editor-extensions/vscode/syntaxes/grain.json
@@ -178,7 +178,7 @@
               }
             },
             {
-              "match": "((@)since)\\s+\\b(v\\d+\\.\\d+\\.\\d+|next)\\b",
+              "match": "((@)since)\\s+\\b(v\\d+\\.\\d+\\.\\d+)\\b",
               "captures": {
                 "1": { "name": "storage.type.graindoc" },
                 "2": { "name": "punctuation.definition.block.tag.graindoc" },


### PR DESCRIPTION
I think when the parser was rewritten for graindoc it removed the ability todo `@since: next` this pr makes the syntax highlighting reflect that is no longer valid.