### PR TITLE
feat: Add better autocompletion on block comments

### DIFF
--- a/editor-extensions/vscode/language-configuration.json
+++ b/editor-extensions/vscode/language-configuration.json
@@ -15,7 +15,8 @@
     ["[", "]"],
     ["(", ")"],
     ["\"", "\""],
-    ["'", "'"]
+    ["'", "'"],
+    ["/*", "*/"],
   ],
   // symbols that that can be used to surround a selection
   "surroundingPairs": [
@@ -36,6 +37,17 @@
     {
       // e.g. /** ...|
       "beforeText": "^\\s*\\/\\*\\*(?!\\/)([^\\*]|\\*(?!\\/))*$",
+      "action": { "indent": "none", "appendText": " * " }
+    },
+    {
+      // e.g. /* | */
+      "beforeText": "^\\s*\\/\\*(?!\\/)([^\\*]|\\*(?!\\/))*$",
+      "afterText": "^\\s*\\*\\/$",
+      "action": { "indent": "indentOutdent", "appendText": " * " }
+    },
+    {
+      // e.g. / * ...| <- Space is removed but it was messing up highlighting
+      "beforeText": "^\\s*\\/\\*(?!\\/)([^\\*]|\\*(?!\\/))*$",
       "action": { "indent": "none", "appendText": " * " }
     },
     {

--- a/editor-extensions/vscode/language-configuration.json
+++ b/editor-extensions/vscode/language-configuration.json
@@ -16,7 +16,7 @@
     ["(", ")"],
     ["\"", "\""],
     ["'", "'"],
-    ["/*", "*/"],
+    ["/*", "*/"]
   ],
   // symbols that that can be used to surround a selection
   "surroundingPairs": [


### PR DESCRIPTION
This pr adds better autocomplete on `block` comments not to be confused with `doc` comments.

We now support the auto adding of ` * ` when your in a block comment which we previously only did in `doc` comments. we also now auto-close a block comment for you.