### PR TITLE
fix: Use consistent scope for type variables

### DIFF
--- a/editor-extensions/vscode/syntaxes/grain.json
+++ b/editor-extensions/vscode/syntaxes/grain.json
@@ -233,7 +233,7 @@
         {
           "match": "(\\b[a-z]\\w*\\b)(,)?",
           "captures": {
-            "1": { "name": "variable.parameter.grain" },
+            "1": { "name": "variable.language.grain" },
             "2": { "name": "punctuation.definition.parameters.begin.grain" }
           }
         }


### PR DESCRIPTION
I didn't realize this was the only place it was wrong. I would have just done it in the other PR. Such is life.

<img width="204" alt="image" src="https://github.com/grain-lang/grain-language-server/assets/7244034/6aa23d12-fc31-4122-8cf9-a6dbd04b9340">
