### PR TITLE
feat(vscode): Add Language Status Item

### DIFF
--- a/editor-extensions/vscode/package.json
+++ b/editor-extensions/vscode/package.json
@@ -32,6 +32,10 @@
       {
         "command": "grain.restart",
         "title": "Grain: Restart Language Server"
+      },
+      {
+        "command": "grain.openOutput",
+        "title": "Grain: Show Extension Output"
       }
     ],
     "languages": [

--- a/editor-extensions/vscode/src/GrainErrorHandler.ts
+++ b/editor-extensions/vscode/src/GrainErrorHandler.ts
@@ -1,0 +1,55 @@
+import { LanguageStatusSeverity, type LanguageStatusItem } from "vscode";
+import {
+  ErrorHandler,
+  ErrorAction,
+  CloseAction,
+  type BaseLanguageClient,
+  type ErrorHandlerResult,
+  type Message,
+  type CloseHandlerResult,
+} from "vscode-languageclient";
+
+// Derived from: https://github.com/microsoft/vscode-languageserver-node/blob/a561f1342ba94ad7f550cb15446f65432f5e1367/client/src/common/client.ts#L439
+export default class GrainErrorHandler implements ErrorHandler {
+  private readonly restarts: number[];
+
+  constructor(
+    private name: string,
+    private languageStatusItem: LanguageStatusItem,
+    private maxRestartCount: number
+  ) {
+    this.restarts = [];
+  }
+
+  public error(
+    _error: Error,
+    _message: Message,
+    count: number
+  ): ErrorHandlerResult {
+    if (count && count <= 3) {
+      return { action: ErrorAction.Continue };
+    }
+    return { action: ErrorAction.Shutdown };
+  }
+
+  public closed(): CloseHandlerResult {
+    this.restarts.push(Date.now());
+    if (this.restarts.length <= this.maxRestartCount) {
+      return { action: CloseAction.Restart };
+    } else {
+      const diff = this.restarts[this.restarts.length - 1] - this.restarts[0];
+      if (diff <= 3 * 60 * 1000) {
+        this.languageStatusItem.severity = LanguageStatusSeverity.Error;
+        return {
+          action: CloseAction.DoNotRestart,
+          message: `The ${this.name} server crashed ${
+            this.maxRestartCount + 1
+          } times in the last 3 minutes. The server will not be restarted. See the output for more information.`,
+        };
+      } else {
+        this.restarts.shift();
+        return { action: CloseAction.Restart };
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds a languageStatusItem to the vscode extension [VSCODE Status Item](https://code.visualstudio.com/api/ux-guidelines/status-bar) specifically this provides a place for us to list the grain extension commands and display stats about the server.

This pr also contributes a new `openOutput` command which opens the grain extension output window.

The statusBar item currently only shows an error severity when the lsp crashes out. But we can extend the functionality in the future similar to how rescript tracks status [here](https://github.com/rescript-lang/rescript-vscode/blob/8849a583855d85c199af617af4dac18fd1de23da/client/src/extension.ts#L151C45-L151C64) and have it show things such as if the lsp is busy during formatting.
![image](https://github.com/user-attachments/assets/c005ed51-2543-427d-adb9-d26b45e7f544)
